### PR TITLE
[feature] add --gnu flag to support MDK Project

### DIFF
--- a/rt-thread/SConscript
+++ b/rt-thread/SConscript
@@ -28,7 +28,16 @@ if GetDepend(["PKG_TINYUSB_DEVICE_CDC"]):
 
 if GetDepend(["PKG_TINYUSB_DEVICE_MSC"]):
     src += ["../src/class/msc/msc_device.c", "port/msc_device.c"]
+  
+LOCAL_CCFLAGS = ''
 
-group = DefineGroup('tinyusb', src, depend = ['PKG_USING_TINYUSB'], CPPPATH = path)
+if rtconfig.PLATFORM == 'gcc': # GCC
+    LOCAL_CCFLAGS += ' -std=c99'
+elif rtconfig.PLATFORM == 'armcc': # Keil AC5
+    LOCAL_CCFLAGS += ' --c99 --gnu -g -W'
+elif rtconfig.PLATFORM == 'armclang': # Keil AC6
+    LOCAL_CCFLAGS += ' -std=c99 -g -w'
+    
+group = DefineGroup('tinyusb', src, depend = ['PKG_USING_TINYUSB'], CPPPATH = path, LOCAL_CCFLAGS = LOCAL_CCFLAGS)
 
 Return('group')


### PR DESCRIPTION
tinyusb代码中未添加MDK armcc 编译器支持，如果使用MDK编译tinyusb，需要添加--gnu的扩展选项，这里在软件包中添加该配置，后续所有MDK环境汇中（即使本身未添加--gnu配置），使用该软件包也不会有报错了。
